### PR TITLE
Workaround for neovim issue neovim/neovim#5902

### DIFF
--- a/autoload/incsearch/util.vim
+++ b/autoload/incsearch/util.vim
@@ -181,7 +181,7 @@ function! s:funcmanage() abort
 endfunction
 
 function! s:dictfunction(dictfunc, dict) abort
-  let funcname = '_' . matchstr(string(a:dictfunc), '\d\+')
+  silent! let funcname = '_' . matchstr(string(a:dictfunc), '\d\+')
   let s:funcmanage[funcname] = {
   \   'func': a:dictfunc,
   \   'dict': a:dict


### PR DESCRIPTION
This silents the error `"E724: unable to correctly dump variable with self-referencing container" when using incsearch`

in neovim. See details in neovim issue https://github.com/neovim/neovim/issues/5902