### PR TITLE
dictfunction: use get({func}, {what}) if possible

### DIFF
--- a/autoload/incsearch/util.vim
+++ b/autoload/incsearch/util.vim
@@ -181,7 +181,11 @@ function! s:funcmanage() abort
 endfunction
 
 function! s:dictfunction(dictfunc, dict) abort
-  let funcname = '_' . matchstr(string(a:dictfunc), '\d\+')
+  if has('patch-7.4.1842')
+    let funcname = '_' . get(a:dictfunc, 'name')
+  else
+    let funcname = '_' . matchstr(string(a:dictfunc), '\d\+')
+  endif
   let s:funcmanage[funcname] = {
   \   'func': a:dictfunc,
   \   'dict': a:dict


### PR DESCRIPTION
This avoids somewhat hacky use of `string()`.
Instead, prefer to canonical api `get({func}, {what})`
on vim 7.4.1842 above or neovim.

Fixes #125.