### PR TITLE
docs: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 > See:
 > - https://medium.com/@haya14busa/incsearch-vim-is-dead-long-live-incsearch-2b7070d55250
 > - https://github.com/vim/vim/pull/2198
+> - Successor plugin: https://github.com/haya14busa/is.vim
 
 
 ![incsearch.vim](https://raw.githubusercontent.com/haya14busa/i/master/incsearch.vim/incsearch_logo.png)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+
+> ⚠️ **Deprecated**
+> This plugin is no longer necessary since the main functionality is now built into vim/neovim
+>
+> See:
+> - https://medium.com/@haya14busa/incsearch-vim-is-dead-long-live-incsearch-2b7070d55250
+> - https://github.com/vim/vim/pull/2198
+
+
 ![incsearch.vim](https://raw.githubusercontent.com/haya14busa/i/master/incsearch.vim/incsearch_logo.png)
 
 [![Build Status](https://travis-ci.org/haya14busa/incsearch.vim.svg?branch=master)](https://travis-ci.org/haya14busa/incsearch.vim)


### PR DESCRIPTION
Thank you so much for creating this plugin and for your contribution to Vim!  🙇🏻 
For many years incsearch.vim was a must-have plugin on any Vim setup I ever worked on and I'm sure others feel the same.

It still works great (with the few caveats of some minor Neovim rendering issue [#79], and clash with the suggested mappings configuration for nvim-cmp). These issues led me to search for a solution, and after awhile I got to your blog post and realized that I no longer need to use this plugin if the main functionality is built into Vim. I figured it would be nice to help others find your blog post and Vim PR more easily.

Feel free to edit or discard this PR if you don't want to deprecate this plugin after all.

Cheers!